### PR TITLE
- npm: Bump version in `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kld-path-parser",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This is the only issue I have caught so far. `kld-transform-parser` looks good too.

Btw, if you are using [semver](https://semver.org/spec/v2.0.0.html), I do think you are supposed to bump the minor version though when adding features. It is only the first number, the major number, which needs incrementing on a breaking change. The last, patch version is only for fixes.